### PR TITLE
chore(deps): Lower minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 
 
 [dependencies]
-console = { version = "0.15.8", optional = true }
-serde = { version = "1.0.213", features = ["derive"], optional = true }
+console = { version = "0.15.0", optional = true }
+serde = { version = "1.0.0", features = ["derive"], optional = true }
 
 
 [features]


### PR DESCRIPTION
Currently the minimal versions for this package are set needlessly high, we can lower them to the lowest backwards compatible version, as it does not seem to use any features introduced in later versions.
